### PR TITLE
Improve consumer recovery in case of a node crash

### DIFF
--- a/lib/ElmerFudd/direct_handler.rb
+++ b/lib/ElmerFudd/direct_handler.rb
@@ -3,20 +3,26 @@ module ElmerFudd
     include Filter
     attr_reader :route
 
-    def initialize(route, callback, filters)
+    def initialize(route, callback, filters, durable:)
       @route = route
       @callback = callback
       @filters = filters
+      @durable = durable
     end
 
     def queue(env)
-      env.channel.queue(@route.queue_name, durable: true, exclusive: is_exclusive_queue).tap do |queue|
+      ensure_that_queue_exists(env)
+      env.channel.queue(@route.queue_name, durable: @durable, exclusive: is_exclusive_queue).tap do |queue|
         unless @route.exchange_name == ""
           Array(@route.routing_keys).each do |routing_key|
             queue.bind(exchange(env), routing_key: routing_key)
           end
         end
       end
+    end
+
+    def ensure_that_queue_exists(env)
+      env.channel.queue_declare(@route.queue_name, durable: @durable, exclusive: is_exclusive_queue)
     end
 
     def exchange(env)

--- a/lib/ElmerFudd/direct_handler.rb
+++ b/lib/ElmerFudd/direct_handler.rb
@@ -18,6 +18,7 @@ module ElmerFudd
             queue.bind(exchange(env), routing_key: routing_key)
           end
         end
+        @route.queue_name = queue.name
       end
     end
 

--- a/lib/ElmerFudd/version.rb
+++ b/lib/ElmerFudd/version.rb
@@ -1,3 +1,3 @@
 module ElmerFudd
-  VERSION = "0.0.28"
+  VERSION = "0.0.29"
 end


### PR DESCRIPTION
- Allow non-durable queues
  Not replicated durable queues, if their node dies, can not be recreated
  on another node until their owner node is back or removed from the
  cluster.
  This change allows to declare worker as worker with non-durable queues

``` ruby
class Worker < ElmerFudd::Worker
  self.durable_queues = false
  # ....
end
```
- Consumers will try automatically to recreate the non-durable queue and
  re-subscribe to it in case the server sends a Consumer Cancel Notification (the node where the queue was living on has disappeared).
