### PR TITLE
Puma server support

### DIFF
--- a/ElmerFudd.gemspec
+++ b/ElmerFudd.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bunny", '>= 1.6.3'
+  spec.add_dependency "connection_pool", '>= 2.2.0'
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest", "~> 5.7"

--- a/lib/ElmerFudd/publisher.rb
+++ b/lib/ElmerFudd/publisher.rb
@@ -1,49 +1,84 @@
+require 'connection_pool'
+
 module ElmerFudd
   class Publisher
-    def initialize(connection, uuid_service: -> { rand.to_s }, logger: Logger.new($stdout))
+    class Exchange
+      def initialize(connection)
+        @channel = connection.create_channel
+        @reply_channel = connection.create_channel
+        @direct = @channel.default_exchange
+        @topic_x = {}
+      end
+
+      attr_reader :direct
+
+      def rpc_reply_queue
+        @rpc_reply_queue ||= @reply_channel.queue("", exclusive: true)
+      end
+
+      def cancel_reply_consumer(consumer_tag)
+        @reply_channel.consumers[consumer_tag].cancel
+      end
+
+      def topic(name)
+        @topic_x[name] ||= @channel.topic(name)
+      end
+    end
+
+    def initialize(connection, uuid_service: -> { rand.to_s }, logger: Logger.new($stdout),
+                   max_threads: 4)
       @connection = connection
       @logger = logger
       @uuid_service = uuid_service
-      @topic_x = {}
+      @exchange = ConnectionPool.new(size: max_threads, timeout: 3) do
+        Exchange.new(connection)
+      end
     end
 
     def notify(topic_exchange, routing_key, payload)
-      @logger.debug "ElmerFudd: NOTIFY - topic_exchange: #{topic_exchange}, routing_key: #{routing_key}, payload: #{payload}"
-      @topic_x[topic_exchange] ||= channel.topic(topic_exchange)
-      @topic_x[topic_exchange].publish payload.to_s, routing_key: routing_key
+      @exchange.with do |exchange|
+        @logger.debug "ElmerFudd: NOTIFY - topic_exchange: #{topic_exchange}, routing_key: #{routing_key}, payload: #{payload}"
+        exchange.topic(topic_exchange).publish payload.to_s, routing_key: routing_key
+      end
       nil
     end
 
     def cast(queue_name, payload)
-      @logger.debug "ElmerFudd: CAST - queue_name: #{queue_name}, payload: #{payload}"
-      x.publish(payload.to_s, routing_key: queue_name)
+      @exchange.with do |exchange|
+        @logger.debug "ElmerFudd: CAST - queue_name: #{queue_name}, payload: #{payload}"
+        exchange.direct.publish(payload.to_s, routing_key: queue_name)
+      end
       nil
     end
 
     def call(queue_name, payload, timeout: 10)
-      @logger.debug "ElmerFudd: CALL - queue_name: #{queue_name}, payload: #{payload}, timeout: #{timeout}"
-      mutex = Mutex.new
-      resource = ConditionVariable.new
-      correlation_id = @uuid_service.call
-      consumer_tag = @uuid_service.call
-      response = nil
+      @exchange.with do |exchange|
+        begin
+          @logger.debug "ElmerFudd: CALL - queue_name: #{queue_name}, payload: #{payload}, timeout: #{timeout}"
+          mutex = Mutex.new
+          resource = ConditionVariable.new
+          correlation_id = @uuid_service.call
+          consumer_tag = @uuid_service.call
+          response = nil
 
-      Timeout.timeout(timeout) do
-        rpc_reply_queue.subscribe(manual_ack: false, block: false, consumer_tag: consumer_tag) do |delivery_info, properties, payload|
-          if properties[:correlation_id] == correlation_id
-            response = payload
-            mutex.synchronize { resource.signal }
+          Timeout.timeout(timeout) do
+            exchange.rpc_reply_queue.subscribe(manual_ack: false, block: false, consumer_tag: consumer_tag) do |delivery_info, properties, payload|
+              if properties[:correlation_id] == correlation_id
+                response = payload
+                mutex.synchronize { resource.signal }
+              end
+            end
+
+            exchange.direct.publish(payload.to_s, routing_key: queue_name, reply_to: exchange.rpc_reply_queue.name,
+                                    correlation_id: correlation_id)
+
+            mutex.synchronize { resource.wait(mutex) unless response }
+            response
           end
+        ensure
+          exchange.cancel_reply_consumer(consumer_tag)
         end
-
-        x.publish(payload.to_s, routing_key: queue_name, reply_to: rpc_reply_queue.name,
-                  correlation_id: correlation_id)
-
-        mutex.synchronize { resource.wait(mutex) unless response }
-        response
       end
-    ensure
-      reply_channel.consumers[consumer_tag].cancel
     end
 
     private
@@ -52,22 +87,6 @@ module ElmerFudd
       @connection.tap do |c|
         c.start unless c.connected?
       end
-    end
-
-    def x
-      @x ||= channel.default_exchange
-    end
-
-    def channel
-      @channel ||= connection.create_channel
-    end
-
-    def reply_channel
-      @reply_channel ||= connection.create_channel
-    end
-
-    def rpc_reply_queue
-      @rpc_reply_queue ||= reply_channel.queue("", exclusive: true)
     end
   end
 end


### PR DESCRIPTION
Puma server spawns multiple threads to serve requests. In such case it should be possible to publish messages from many threads at once. In Bunny implementation Connection may be shared between threads, but not the channel.

This PR extracts channel operations and provides a pool to use within a threaded application. 
