### PR TITLE
Fix content type header for Json

### DIFF
--- a/lib/ElmerFudd.rb
+++ b/lib/ElmerFudd.rb
@@ -4,6 +4,8 @@ require 'thread'
 require 'json'
 
 module ElmerFudd
+  DEFAULT_CONTENT_TYPE = Bunny::Channel::DEFAULT_CONTENT_TYPE
+
   require 'ElmerFudd/publisher'
   require 'ElmerFudd/json_publisher'
 

--- a/lib/ElmerFudd/direct_handler.rb
+++ b/lib/ElmerFudd/direct_handler.rb
@@ -2,12 +2,15 @@ module ElmerFudd
   class DirectHandler
     include Filter
     attr_reader :route
+    attr_accessor :call_reply_content_type
 
     def initialize(route, callback, filters, options)
       @route = route
       @callback = callback
       @filters = filters
       @durable = options.fetch(:durable)
+      @call_reply_content_type = ElmerFudd::DEFAULT_CONTENT_TYPE
+      initialize_filters
     end
 
     def queue(env)
@@ -37,6 +40,11 @@ module ElmerFudd
     end
 
     private
+
+    def initialize_filters
+      @filters.select { |filter| filter.respond_to?(:setup) }.
+        each { |filter| filter.setup(self) }
+    end
 
     def filters_names
       @filters.map { |f| f.respond_to?(:name) ? f.name : f.class.name }

--- a/lib/ElmerFudd/json_filter.rb
+++ b/lib/ElmerFudd/json_filter.rb
@@ -1,6 +1,11 @@
 module ElmerFudd
   class JsonFilter
     extend Filter
+
+    def self.setup(handler)
+      handler.call_reply_content_type = 'application/json'
+    end
+
     def self.call(env, message, filters)
       message.payload = JSON.parse(message.payload)
       {result: call_next(env, message, filters)}.to_json

--- a/lib/ElmerFudd/json_publisher.rb
+++ b/lib/ElmerFudd/json_publisher.rb
@@ -1,15 +1,17 @@
 module ElmerFudd
   class JsonPublisher < Publisher
-    def notify(topic_exchange, routing_key, payload)
-      super(topic_exchange, routing_key, payload.to_json)
+    CONTENT_TYPE = 'application/json'
+
+    def notify(topic_exchange, routing_key, payload, content_type: CONTENT_TYPE)
+      super(topic_exchange, routing_key, payload.to_json, content_type: content_type)
     end
 
-    def cast(queue_name, payload)
-      super(queue_name, payload.to_json)
+    def cast(queue_name, payload, content_type: CONTENT_TYPE)
+      super(queue_name, payload.to_json, content_type: content_type)
     end
 
-    def call(queue_name, payload, **kwargs)
-      JSON.parse(super(queue_name, payload.to_json, **kwargs))
+    def call(queue_name, payload, content_type: CONTENT_TYPE, **kwargs)
+      JSON.parse(super(queue_name, payload.to_json, content_type: content_type, **kwargs))
     end
   end
 end

--- a/lib/ElmerFudd/publisher.rb
+++ b/lib/ElmerFudd/publisher.rb
@@ -35,7 +35,7 @@ module ElmerFudd
       end
     end
 
-    def notify(topic_exchange, routing_key, payload)
+    def notify(topic_exchange, routing_key, payload, content_type: ElmerFudd::DEFAULT_CONTENT_TYPE)
       @exchange.with do |exchange|
         @logger.debug "ElmerFudd: NOTIFY - topic_exchange: #{topic_exchange}, routing_key: #{routing_key}, payload: #{payload}"
         exchange.topic(topic_exchange).publish payload.to_s, routing_key: routing_key
@@ -43,7 +43,7 @@ module ElmerFudd
       nil
     end
 
-    def cast(queue_name, payload)
+    def cast(queue_name, payload, content_type: ElmerFudd::DEFAULT_CONTENT_TYPE)
       @exchange.with do |exchange|
         @logger.debug "ElmerFudd: CAST - queue_name: #{queue_name}, payload: #{payload}"
         exchange.direct.publish(payload.to_s, routing_key: queue_name)
@@ -51,7 +51,7 @@ module ElmerFudd
       nil
     end
 
-    def call(queue_name, payload, timeout: 10)
+    def call(queue_name, payload, timeout: 10, content_type: ElmerFudd::DEFAULT_CONTENT_TYPE)
       @exchange.with do |exchange|
         begin
           @logger.debug "ElmerFudd: CALL - queue_name: #{queue_name}, payload: #{payload}, timeout: #{timeout}"
@@ -69,7 +69,9 @@ module ElmerFudd
               end
             end
 
-            exchange.direct.publish(payload.to_s, routing_key: queue_name, reply_to: exchange.rpc_reply_queue.name,
+            exchange.direct.publish(payload.to_s,
+                                    content_type: content_type,
+                                    routing_key: queue_name, reply_to: exchange.rpc_reply_queue.name,
                                     correlation_id: correlation_id)
 
             mutex.synchronize { resource.wait(mutex) unless response }

--- a/lib/ElmerFudd/rpc_handler.rb
+++ b/lib/ElmerFudd/rpc_handler.rb
@@ -7,7 +7,9 @@ module ElmerFudd
     end
 
     def reply(env, original_message, response)
-      exchange(env).publish(response.to_s, routing_key: original_message.properties.reply_to,
+      exchange(env).publish(response.to_s,
+                            content_type: call_reply_content_type,
+                            routing_key: original_message.properties.reply_to,
                             correlation_id: original_message.properties.correlation_id)
     end
   end


### PR DESCRIPTION
Set proper content-type header for published messages via JsonPublisher. Replies from RpcHandler have the header set when JsonFilter is used
