### PR TITLE
add_single_channel_property_to_worker

### DIFF
--- a/lib/ElmerFudd/worker.rb
+++ b/lib/ElmerFudd/worker.rb
@@ -8,6 +8,7 @@ module ElmerFudd
       attr_writer :durable_queues
       def durable_queues; @durable_queues.nil? ? true : @durable_queues; end
 
+      # When set to true, every handler will receive a separate channel
       attr_writer :single_channel
       def single_channel; @single_channel.nil? ? true : @single_channel; end
     end

--- a/test/smoke/cast_test.rb
+++ b/test/smoke/cast_test.rb
@@ -27,7 +27,7 @@ class CastTest < MiniTest::Test
     @publisher.cast TEST_QUEUE, message: "hello"
 
     Timeout.timeout(0.5) do
-      assert "hello", $responses.pop
+      assert_equal "hello", $responses.pop
     end
   end
 
@@ -45,7 +45,7 @@ class CastTest < MiniTest::Test
     @publisher.cast TEST_QUEUE, message: "hello2"
 
     Timeout.timeout(0.5) do
-      assert "hello2", $responses.pop
+      assert_equal "hello2", $responses.pop
     end
   end
 

--- a/test/smoke/single_channel_test.rb
+++ b/test/smoke/single_channel_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class SingleChannelTest < MiniTest::Test
+  include RabbitHelper
+  TEST_QUEUE = "test.ElmerFudd.cast"
+  TEST_QUEUE_2 = "test.ElmerFudd.cast"
+
+  class TestWorker < ElmerFudd::Worker
+    default_filters ElmerFudd::JsonFilter
+    self.single_channel = false
+
+    handle_cast(Route(TEST_QUEUE)) do |_env, message|
+      if delay = message.payload["delay"]
+        sleep delay
+      end
+
+      $responses << message.payload["message"]
+    end
+
+    handle_cast(Route(TEST_QUEUE_2)) do |_env, message|
+      if delay = message.payload["delay"]
+        sleep delay
+      end
+
+      $responses << message.payload["message"]
+    end
+  end
+
+  def teardown
+    remove_queue TEST_QUEUE
+    remove_queue TEST_QUEUE_2
+    super
+  end
+
+  def test_basic_cast
+    start_worker TestWorker
+    @publisher.cast TEST_QUEUE, message: "hello1", delay: 0.9
+    @publisher.cast TEST_QUEUE_2, message: "hello2", delay: 0.9
+
+    Timeout.timeout(1) do
+      assert_equal %w(hello1 hello2), [$responses.pop, $responses.pop].sort
+    end
+  end
+end


### PR DESCRIPTION
this will allow workers to process queues independently
